### PR TITLE
Manually implement Clone trait for Pool struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,13 +110,25 @@ impl<DB: sqlx::Database> PoolBuilder<DB> {
 /// An asynchronous pool of SQLx database connections with tracing instrumentation.
 ///
 /// Wraps a SQLx [`Pool`] and propagates tracing attributes to all acquired connections.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Pool<DB>
 where
     DB: sqlx::Database,
 {
     inner: sqlx::Pool<DB>,
     attributes: Arc<Attributes>,
+}
+
+impl<DB> Clone for Pool<DB> 
+where
+    DB: sqlx::Database,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            attributes: self.attributes.clone(),
+        }
+    }
 }
 
 impl<DB> From<sqlx::Pool<DB>> for Pool<DB>


### PR DESCRIPTION
Manually implement Clone to avoid unnecessary DB: Clone bound from derive macro.

As `sqlx::Postgres` and `sql::Sqlite` are not `Clone` it makes the pool non-cloneable.  https://smallcultfollowing.com/babysteps/blog/2022/04/12/implied-bounds-and-perfect-derive/ provides more information on the reasons for the derive behaviour.