### PR TITLE
fix: Adjust `Clone` implementation for `Pool`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-tracing"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlx-tracing"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "OpenTelemetry-compatible tracing for SQLx database operations in Rust."
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,13 +110,25 @@ impl<DB: sqlx::Database> PoolBuilder<DB> {
 /// An asynchronous pool of SQLx database connections with tracing instrumentation.
 ///
 /// Wraps a SQLx [`Pool`] and propagates tracing attributes to all acquired connections.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Pool<DB>
 where
     DB: sqlx::Database,
 {
     inner: sqlx::Pool<DB>,
     attributes: Arc<Attributes>,
+}
+
+impl<DB> Clone for Pool<DB>
+where
+    DB: sqlx::Database,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            attributes: Arc::clone(&self.attributes),
+        }
+    }
 }
 
 impl<DB> From<sqlx::Pool<DB>> for Pool<DB>
@@ -126,7 +138,7 @@ where
 {
     /// Convert a SQLx [`Pool`] into a tracing-instrumented [`Pool`].
     fn from(inner: sqlx::Pool<DB>) -> Self {
-        PoolBuilder::from(inner).build()
+        PoolBuilder::from(inner.into()).build()
     }
 }
 

--- a/tests/postgres.rs
+++ b/tests/postgres.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use sqlx::Postgres;
+use sqlx_tracing::Pool;
 use testcontainers::{
     GenericImage, ImageExt,
     core::{ContainerPort, WaitFor},
@@ -77,4 +78,10 @@ async fn execute() {
         )
         .await;
     }
+}
+
+#[test]
+fn pool_postgres_is_clone() {
+    fn assert_clone<T: Clone>() {}
+    assert_clone::<Pool<Postgres>>();
 }


### PR DESCRIPTION
The derived Clone implementation is too restrictive and causes a compilation error when used in a struct that also derives the Clone trait.

```
the trait `Clone` is not implemented for `Postgres`
```

Changing to a manual implementation of Clone more closely matches the behavior of the `sqlx` library.