### PR TITLE
feat(pool): Add try_begin method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,19 @@ where
             attributes: self.attributes.clone(),
         })
     }
-
+    
+    /// Attempts to retrieve a connection and immediately begins a new transaction if successful.
+    ///
+    /// The returned [`Transaction`] is instrumented for tracing.
+    pub async fn try_begin<'c>(&'c self) -> Result<Option<Transaction<'c, DB>>, sqlx::Error> {
+        self.inner.try_begin().await.map(|t| {
+            t.map(|inner| Transaction {
+                inner,
+                attributes: self.attributes.clone(),
+            })
+        })
+    }
+    
     /// Acquires a pooled connection, instrumented for tracing.
     pub async fn acquire(&self) -> Result<PoolConnection<DB>, sqlx::Error> {
         self.inner.acquire().await.map(|inner| PoolConnection {


### PR DESCRIPTION
# Description
* Added `try_begin` method on `Pool` like in sqlx : https://docs.rs/sqlx/latest/sqlx/struct.Pool.html#method.try_begin

# Why is this needed
Through the sqlx_tracing::Pool we cannot access this sqlx::Pool method