### PR TITLE
Inner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-tracing"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlx-tracing"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "OpenTelemetry-compatible tracing for SQLx database operations in Rust."
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,13 +110,25 @@ impl<DB: sqlx::Database> PoolBuilder<DB> {
 /// An asynchronous pool of SQLx database connections with tracing instrumentation.
 ///
 /// Wraps a SQLx [`Pool`] and propagates tracing attributes to all acquired connections.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Pool<DB>
 where
     DB: sqlx::Database,
 {
     inner: sqlx::Pool<DB>,
     attributes: Arc<Attributes>,
+}
+
+impl<DB> Clone for Pool<DB>
+where
+    DB: sqlx::Database,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            attributes: Arc::clone(&self.attributes),
+        }
+    }
 }
 
 impl<DB> From<sqlx::Pool<DB>> for Pool<DB>
@@ -126,7 +138,7 @@ where
 {
     /// Convert a SQLx [`Pool`] into a tracing-instrumented [`Pool`].
     fn from(inner: sqlx::Pool<DB>) -> Self {
-        PoolBuilder::from(inner).build()
+        PoolBuilder::from(inner.into()).build()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,14 @@ where
             inner,
         })
     }
+
+    /// Returns the inner sql::Pool
+    ///
+    /// For cases where tracing is not required, or where access to
+    /// sqlx-traits are needed, eg running migrations.
+    pub fn inner(&self) -> sqlx::Pool<DB> {
+        self.inner.clone()
+    }
 }
 
 /// Wrapper for a mutable SQLx connection reference with tracing attributes.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,4 +1,5 @@
 use futures::{StreamExt, TryStreamExt};
+use sqlx::Error;
 use tracing::Instrument;
 
 impl<'c, DB> crate::Transaction<'c, DB>
@@ -14,6 +15,16 @@ where
             inner: &mut *self.inner,
             attributes: self.attributes.clone(),
         }
+    }
+
+    /// Commits this transaction or savepoint.
+    pub async fn commit(self) -> Result<(), Error> {
+        self.inner.commit().await
+    }
+
+    /// Aborts this transaction or savepoint.
+    pub async fn rollback(self) -> Result<(), Error> {
+        self.inner.rollback().await
     }
 }
 

--- a/tests/postgres.rs
+++ b/tests/postgres.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use sqlx::Postgres;
+use sqlx_tracing::Pool;
 use testcontainers::{
     GenericImage, ImageExt,
     core::{ContainerPort, WaitFor},
@@ -77,4 +78,10 @@ async fn execute() {
         )
         .await;
     }
+}
+
+#[test]
+fn pool_postgres_is_clone() {
+    fn assert_clone<T: Clone>() {}
+    assert_clone::<Pool<Postgres>>();
 }


### PR DESCRIPTION
Add function sqlx_tracing::Pool::inner(&self) -> sqlx::Pool to give access to the inner Poll for cases where tracing is not required or where access to traits or methods that sqlx_tracing does not supply is needed, eg sqlx::migration::run().