### PR TITLE
fix: relax Clone bound on Pool<DB>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ where
             attributes: self.attributes.clone(),
         })
     }
-    
+
     /// Attempts to retrieve a connection and immediately begins a new transaction if successful.
     ///
     /// The returned [`Transaction`] is instrumented for tracing.
@@ -167,7 +167,7 @@ where
             })
         })
     }
-    
+
     /// Acquires a pooled connection, instrumented for tracing.
     pub async fn acquire(&self) -> Result<PoolConnection<DB>, sqlx::Error> {
         self.inner.acquire().await.map(|inner| PoolConnection {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,13 +110,25 @@ impl<DB: sqlx::Database> PoolBuilder<DB> {
 /// An asynchronous pool of SQLx database connections with tracing instrumentation.
 ///
 /// Wraps a SQLx [`Pool`] and propagates tracing attributes to all acquired connections.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Pool<DB>
 where
     DB: sqlx::Database,
 {
     inner: sqlx::Pool<DB>,
     attributes: Arc<Attributes>,
+}
+
+impl<DB> Clone for Pool<DB>
+where
+    DB: sqlx::Database,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            attributes: self.attributes.clone(),
+        }
+    }
 }
 
 impl<DB> From<sqlx::Pool<DB>> for Pool<DB>

--- a/tests/postgres.rs
+++ b/tests/postgres.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use sqlx::Postgres;
+use sqlx_tracing::Pool;
 use testcontainers::{
     GenericImage, ImageExt,
     core::{ContainerPort, WaitFor},
@@ -77,4 +78,10 @@ async fn execute() {
         )
         .await;
     }
+}
+
+#[test]
+fn pool_postgres_is_clone() {
+    fn assert_clone<T: Clone>() {}
+    assert_clone::<Pool<Postgres>>();
 }

--- a/tests/sqlite.rs
+++ b/tests/sqlite.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "sqlite")]
 
 use sqlx::Sqlite;
+use sqlx_tracing::Pool;
 
 mod common;
 
@@ -30,4 +31,10 @@ async fn execute() {
         )
         .await;
     }
+}
+
+#[test]
+fn pool_sqlite_is_clone() {
+    fn assert_clone<T: Clone>() {}
+    assert_clone::<Pool<Sqlite>>();
 }


### PR DESCRIPTION
## Summary
- Replace `#[derive(Clone)]` on `Pool<DB>` with a manual impl, dropping the spurious `DB: Clone` bound (sqlx database markers like `Postgres`/`Sqlite` don't implement `Clone`, but `sqlx::Pool<DB>` itself does).
- Add compile-time `assert_clone` checks for `Pool<Postgres>` and `Pool<Sqlite>` to lock in the contract.

Alternative to #6, addressing review feedback: drops the unrelated `inner.into()` change, keeps `self.attributes.clone()` for consistency with the rest of the file, and mirrors the test on the sqlite side. No version bump, leave that to the next release.
